### PR TITLE
rename self.tokenizer_args to tokenizer_kargs in text_encoder.py

### DIFF
--- a/src/models/modules/text_encoder.py
+++ b/src/models/modules/text_encoder.py
@@ -99,7 +99,7 @@ class HuggingFaceTextEncoder(BaseTextEncoder):
         tokenizer_kargs['return_tensors'] = 'pt'
         
         inputs = self.tokenizer(
-            texts, **self.tokenizer_args
+            texts, **tokenizer_kargs
         )
         inputs = {
             key: value.to(self.device) for key, value in inputs.items()


### PR DESCRIPTION
[text_encoder.py]

'self.tokenizer_args' was being used like an instance variable inside the huggingsface text encoder class, 
In fact, it was never defined in '_init__' and was considered a local variable that came in as a factor of the '_forward()' function, so we decided that it was an expression that should not be added 'self.' 
For this reason, I modified that part to 'tokenizer_kargs'. 
In addition, even within the CLIPText Encoder class, it is used as ‘tokenizer_kargs’ without ‘self.’ rather than 'self. tokenizer_args', so I think the correction is appropriate from a consistency and grammatical point of view.

Please feel free to let me know if this change doesn't fit your design intentions, or if there's a better way to do it. Please give me feedback and I'll be happy to modify it. Thank you!




[text_encoder.py]

‘self.tokenizer_args’는 HuggingFaceTextEncoder 클래스 내부에서 인스턴스 변수처럼 사용되고 있었지만, 
실제로는 (‘__init__’)에서 정의된 적도 없고 ‘_forward()’ 함수의 인자로 들어오는 지역 변수이기 때문에 ‘self.’를 붙이면 안 되는 표현이라고 판단했습니다. 
이와 같은 이유로 해당 부분을 ‘tokenizer_kargs’로 수정하였습니다. 
또한, CLIPTextEncoder 클래스 내에서도 'self.tokenizer_args'가 아닌 self. 없이 tokenizer_kargs로 사용하고 있어, 일관성과 문법적인 관점에서도 수정이 적절하다고 생각합니다.

혹시 이 변경 사항이 작성자님의 설계 의도와 맞지 않거나, 더 나은 방식이 있다면 언제든지 말씀해 주세요. 피드백 주시면 기꺼이 수정하겠습니다. 감사합니다!